### PR TITLE
Add additional support for dash

### DIFF
--- a/crates/rhai_impl/src/updates/listen.rs
+++ b/crates/rhai_impl/src/updates/listen.rs
@@ -20,7 +20,7 @@ use nix::{
 };
 use rhai::Map;
 use shared_utils::extract_props::*;
-use std::process::{Command as synced_command, Stdio};
+use std::process::Stdio;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tokio::process::Command;
@@ -30,6 +30,7 @@ use tokio::sync::watch;
 pub fn handle_listen(
     var_name: String,
     props: &Map,
+    shell: String,
     store: ReactiveVarStore,
     tx: tokio::sync::mpsc::UnboundedSender<String>,
 ) {
@@ -55,18 +56,7 @@ pub fn handle_listen(
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
     SHUTDOWN_REGISTRY.lock().unwrap().push(shutdown_tx.clone());
 
-    // Check Dash and prefer if dash is installed.
-
-    let dash_installed: bool = synced_command::new("which")
-        .arg("dash")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-
-    let shell: &str = if dash_installed { "/bin/dash" } else { "/bin/sh" };
-
     // Task to catch SIGINT and SIGTERM
-
     tokio::spawn({
         let shutdown_tx = shutdown_tx.clone();
         async move {
@@ -87,7 +77,7 @@ pub fn handle_listen(
 
     tokio::spawn(async move {
         let mut child = unsafe {
-            Command::new(shell)
+            Command::new(&shell)
                 .arg("-c")
                 .arg(&cmd)
                 // .kill_on_drop(true)


### PR DESCRIPTION
Automatically detect dash and use it instead of sh if available

## Description

Dash is a faster alternative for sh. It it frequently used in Ubuntu to run background scripts. 

My ram usage reduced to 100 from 450 megabytes while using dash

## Additional Notes

I firstly tried to replace sh but it was too hard to auto install it as dependency when using cargo.

## Checklist

Please make sure you can check all the boxes that apply to this PR.

- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] The documentation in the `docs/content/main` directory has been adjusted to reflect my changes.
- [x] I used `cargo fmt` to automatically format all code before committing
