### PR TITLE
fix: Style provider priority 'APPLICATION (800) >> 900'

### DIFF
--- a/crates/ewwii/src/server.rs
+++ b/crates/ewwii/src/server.rs
@@ -109,11 +109,7 @@ pub fn initialize_server<B: DisplayBackend>(
     };
 
     if let Some(display) = gtk4::gdk::Display::default() {
-        gtk4::style_context_add_provider_for_display(
-            &display,
-            &app.css_provider,
-            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
-        );
+        gtk4::style_context_add_provider_for_display(&display, &app.css_provider, 900);
     }
 
     if let Ok((file_id, css)) = config::scss::parse_scss_from_config(app.paths.get_config_dir()) {

--- a/crates/ewwii/src/widgets/widget_definitions.rs
+++ b/crates/ewwii/src/widgets/widget_definitions.rs
@@ -2193,17 +2193,13 @@ pub(super) fn resolve_rhai_widget_attrs(gtk_widget: &gtk4::Widget, props: &Map) 
         let css_provider = gtk4::CssProvider::new();
         let scss = format!("* {{ {} }}", style_str);
         css_provider.load_from_data(&grass::from_string(scss, &grass::Options::default())?);
-        gtk_widget
-            .style_context()
-            .add_provider(&css_provider, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
+        gtk_widget.style_context().add_provider(&css_provider, 950);
     }
 
     if let Ok(css_str) = get_string_prop(&props, "css", None) {
         let css_provider = gtk4::CssProvider::new();
         css_provider.load_from_data(&grass::from_string(css_str, &grass::Options::default())?);
-        gtk_widget
-            .style_context()
-            .add_provider(&css_provider, gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION);
+        gtk_widget.style_context().add_provider(&css_provider, 950);
     }
 
     if let Ok(valign) = get_string_prop(&props, "valign", None) {


### PR DESCRIPTION
## Description

Setting style provider priority to 900 still uses global theme as fallback just like GTK3 version.

## Checklist
- [X] I added my changes to CHANGELOG.md, if appropriate.
- [X] I used `cargo fmt` to automatically format all code before committing
