### PR TITLE
refactor: Add build flags to reduce build sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,12 @@ shell-words = "1.1.0"
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+[profile.release]
+opt-level = "z"
+lto = "fat"
+panic = "abort"
+strip = "symbols"
+codegen-units = 1
+
+


### PR DESCRIPTION
## Description

This PR creates a build profile for release builds.
With this change unused parts of Rust libaries won't make it into code.

Build size reduced to 6.4 megabytes from 16.5 megabytes.

Since ewwii has a proper log system I also added flags to reduce panic core from Rust.

## Additional Notes

Panic core can be very help full in some cases. It is considerable to enable it back. 

